### PR TITLE
[Suggestion] Ran clang-format with VS Code default.

### DIFF
--- a/examples/app_core_demo/src/main.c
+++ b/examples/app_core_demo/src/main.c
@@ -21,19 +21,17 @@ void main(void)
     sprintf(data, "Hello world!");
     struct mesh_msg msg = {
         .data = data,
-        .len = 12
-    };
-    
+        .len = 12};
+
     k_msleep(2000); // Allow logs time to flush
 
-    while(1)
+    while (1)
     {
         // Send a message every two seconds
         k_msleep(2000);
         LOG_DBG("Sending mesh message. Length: %d", msg.len);
         mesh_send(msg);
     }
-
 }
 
 /**

--- a/mesh_access/include/mesh.h
+++ b/mesh_access/include/mesh.h
@@ -1,9 +1,10 @@
 /**
  * @brief Mesh message struct
  */
-struct mesh_msg {
+struct mesh_msg
+{
     size_t len;
-    uint8_t * data;
+    uint8_t *data;
 };
 
 /**
@@ -24,4 +25,3 @@ int mesh_send(struct mesh_msg msg);
  * @param[in] msg Mesh message struct
  */
 void mesh_receive(struct mesh_msg msg);
-

--- a/mesh_access/src/mesh.c
+++ b/mesh_access/src/mesh.c
@@ -23,20 +23,18 @@
 #include <common.h>
 #include <mesh.h>
 
-
 LOG_MODULE_REGISTER(mesh_access, GLOBAL_LOG_LEVEL);
 
 static int endpoint_id;
 
-int rpmsg_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src, 
-        void *priv)
+int rpmsg_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src,
+             void *priv)
 {
     /* Fill mesh message struct */
     uint8_t msg_data[MAX_MESSAGE_SIZE];
     struct mesh_msg msg = {
         .data = msg_data,
-        .len = len
-    };
+        .len = len};
     memcpy(msg_data, data, len);
 
     /* Call callback function with mesh message */
@@ -62,7 +60,8 @@ int register_endpoint(const struct device *arg)
     int status;
     status = rpmsg_service_register_endpoint("mesh_node", rpmsg_cb);
 
-    if (status < 0) {
+    if (status < 0)
+    {
         LOG_ERR("Registering endpoint failed with %d", status);
         return status;
     }

--- a/net_core/include/ipc.h
+++ b/net_core/include/ipc.h
@@ -1,9 +1,10 @@
 /**
  * @brief IPC Message struct
  */
-struct ipc_msg {
+struct ipc_msg
+{
     size_t len;
-    uint8_t * data;
+    uint8_t *data;
 };
 
 /**
@@ -15,4 +16,3 @@ int ipc_send(struct ipc_msg msg);
  * @brief IPC receive callback
  */
 void ipc_receive(struct ipc_msg msg);
-

--- a/net_core/include/radio.h
+++ b/net_core/include/radio.h
@@ -8,9 +8,9 @@ void init_radio();
 /**
  * @brief Start radio transmission
  */
-int radio_send(uint8_t * data, uint8_t length);
+int radio_send(uint8_t *data, uint8_t length);
 
 /**
  * @brief Receive data from radio
  */
-int radio_receive(uint8_t * data, uint8_t max_length);
+int radio_receive(uint8_t *data, uint8_t max_length);

--- a/net_core/src/ipc.c
+++ b/net_core/src/ipc.c
@@ -23,20 +23,18 @@
 #include <common.h>
 #include <ipc.h>
 
-
 LOG_MODULE_REGISTER(ipc, GLOBAL_LOG_LEVEL);
 
 static int endpoint_id;
 
-int rpmsg_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src, 
-        void *priv)
+int rpmsg_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src,
+             void *priv)
 {
     /* Fill IPC message struct */
     uint8_t msg_data[MAX_MESSAGE_SIZE];
     struct ipc_msg msg = {
         .data = msg_data,
-        .len = len
-    };
+        .len = len};
     memcpy(msg_data, data, len);
 
     /* Call callback function with ipc message */
@@ -61,7 +59,8 @@ int register_endpoint(const struct device *arg)
     int status;
     status = rpmsg_service_register_endpoint("mesh_node", rpmsg_cb);
 
-    if (status < 0) {
+    if (status < 0)
+    {
         LOG_ERR("Registering endpoint failed with %d", status);
         return status;
     }

--- a/net_core/src/main.c
+++ b/net_core/src/main.c
@@ -39,7 +39,7 @@ static void init_power_clock(void)
     nrfx_clock_start(NRF_CLOCK_DOMAIN_HFCLK);
     nrfx_clock_start(NRF_CLOCK_DOMAIN_LFCLK);
     while (!(nrfx_clock_hfclk_is_running() &&
-            nrfx_clock_lfclk_is_running()))
+             nrfx_clock_lfclk_is_running()))
     {
         /* Just waiting */
     }
@@ -50,7 +50,7 @@ static void init_power_clock(void)
  *
  * Forwards messages from IPC layer to Radio layer
  */
-void radio_tx_thread(void * p1, void * p2, void * p3)
+void radio_tx_thread(void *p1, void *p2, void *p3)
 {
     LOG_INF("USB to Radio thread started");
     k_msleep(500);
@@ -73,14 +73,13 @@ void radio_tx_thread(void * p1, void * p2, void * p3)
  *
  * Forwards messages from radio layer to IPC layer
  */
-void radio_rx_thread(void * p1, void * p2, void * p3)
+void radio_rx_thread(void *p1, void *p2, void *p3)
 {
     LOG_INF("Radio to USB thread started");
     k_msleep(500);
     uint8_t radio_rx[MAX_MESSAGE_SIZE];
     struct ipc_msg msg = {
-        .data = radio_rx
-    };
+        .data = radio_rx};
 
     while (true)
     {
@@ -93,7 +92,6 @@ void radio_rx_thread(void * p1, void * p2, void * p3)
         ipc_send(msg);
     }
 }
-
 
 void main(void)
 {
@@ -123,7 +121,7 @@ void main(void)
                     0, K_NO_WAIT);
 
     LOG_INF("Mesh node on network core started.");
-    
+
     k_msleep(2000); // Allow logs time to flush
 }
 
@@ -134,7 +132,8 @@ void main(void)
  */
 void ipc_receive(struct ipc_msg msg)
 {
-    while (k_msgq_put(&ipc_rx_msgq, &msg, K_NO_WAIT) != 0) {
+    while (k_msgq_put(&ipc_rx_msgq, &msg, K_NO_WAIT) != 0)
+    {
         /* message queue is full: purge old data & try again */
         k_msgq_purge(&ipc_rx_msgq);
     }


### PR DESCRIPTION
Example of formatting. Resolves #11. If the defaults are not satisfactory we could use a `.clang-format` file to override them.