### PR TITLE
Refactor radio threads

### DIFF
--- a/net_core/include/ipc.h
+++ b/net_core/include/ipc.h
@@ -15,4 +15,4 @@ int ipc_send(struct ipc_msg msg);
 /**
  * @brief IPC receive callback
  */
-void ipc_receive(struct ipc_msg msg);
+void ipc_receive_cb(struct ipc_msg msg);

--- a/net_core/include/radio.h
+++ b/net_core/include/radio.h
@@ -18,4 +18,4 @@ int radio_send(uint8_t *data, uint8_t length);
  *      function returns, so data should be copied to another buffer or processing should be completed
  *      before returning.
  */
-void radio_receive(uint8_t *data, uint8_t length);
+void radio_receive_cb(uint8_t *data, uint8_t length);

--- a/net_core/src/ipc.c
+++ b/net_core/src/ipc.c
@@ -38,7 +38,7 @@ int rpmsg_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src,
     memcpy(msg_data, data, len);
 
     /* Call callback function with ipc message */
-    ipc_receive(msg);
+    ipc_receive_cb(msg);
 
     return RPMSG_SUCCESS;
 }

--- a/net_core/src/main.c
+++ b/net_core/src/main.c
@@ -52,7 +52,7 @@ void main(void)
 /**
  * @brief Callback for received radio frames
  */
-void radio_receive(uint8_t *data, uint8_t length)
+void radio_receive_cb(uint8_t *data, uint8_t length)
 {
     struct ipc_msg msg = {
         .data = data,
@@ -67,7 +67,7 @@ void radio_receive(uint8_t *data, uint8_t length)
  *
  * Forward messages to mesh network (currently directly to radio)
  */
-void ipc_receive(struct ipc_msg msg)
+void ipc_receive_cb(struct ipc_msg msg)
 {
     if (msg.len > MAX_MESSAGE_SIZE)
     {

--- a/net_core/src/radio.c
+++ b/net_core/src/radio.c
@@ -94,7 +94,7 @@ void radio_rx_thread(void *p1, void *p2, void *p3)
         memcpy(radio_rx, rf_rx_buf + RF_BUFFER_PAYLOAD_OFFSET, length);
         LOG_HEXDUMP_DBG(radio_rx, length, "Radio RX data");
         /* Callback function for received radio frame */
-        radio_receive(radio_rx, length);
+        radio_receive_cb(radio_rx, length);
     }
 }
 


### PR DESCRIPTION
Might not be ideal to call radio_send directly without a queue from ipc_receive, but there will soon be a mesh processing layer in between, so I think we can decide where to queue at that point.

Closes #5